### PR TITLE
Set the station count mv to refresh weekly.

### DIFF
--- a/grails-app/jobs/au/org/emii/aatams/DetectionCountPerStationRefreshMaterializedViewJob.groovy
+++ b/grails-app/jobs/au/org/emii/aatams/DetectionCountPerStationRefreshMaterializedViewJob.groovy
@@ -4,9 +4,9 @@ class DetectionCountPerStationRefreshMaterializedViewJob extends RefreshMaterial
 {
     static triggers =
     {
-        // Execute daily at 8pm.
+        // Execute on Sundays at 7am.
         // Note: first field is seconds (non-standard for cron).
-        cron name: 'refreshDetectionCountPerStationMaterializedDailyTrigger', cronExpression: "0 0 20 * * ?"
+        cron name: 'refreshDetectionCountPerStationMaterializedDailyTrigger', cronExpression: "0 0 7 * 1 ?"
     }
 
     String getViewName()


### PR DESCRIPTION
This view is only used to provide a layer in the portal, so it's not critical that it is updated daily.
We're trying to avoid thrashing the DB (since the detection extract view does need to be updated daily).
