### PR TITLE
Mocking on already instantiated service (instead of class).

### DIFF
--- a/test/integration/au/org/emii/aatams/detection/DetectionControllerTests.groovy
+++ b/test/integration/au/org/emii/aatams/detection/DetectionControllerTests.groovy
@@ -9,23 +9,24 @@ import org.codehaus.groovy.grails.commons.ConfigurationHolder
 class DetectionControllerTests extends AbstractControllerUnitTestCase
 {
 	def dataSource
-	
+	def detectionExtractService
+
 	protected void setUp()
 	{
 		super.setUp()
 
 		permitted = true
 		controller.params.format = "CSV"
-		
+
 		def sql = new Sql(dataSource)
-		
+
 		def viewName = ConfigurationHolder.config.rawDetection.extract.view.name
 		def viewSelect = ConfigurationHolder.config.rawDetection.extract.view.select
 		sql.execute ('create view ' + viewName + ' as ' + viewSelect)
 
-        DetectionExtractService.metaClass.getDetectionExtractViewName = { viewName }
+        detectionExtractService.metaClass.getDetectionExtractViewName = { viewName }
 	}
-	
+
 	void testExecuteDetectionExtract()
 	{
 		assertExport([:], "testExecuteDetection")
@@ -35,9 +36,9 @@ class DetectionControllerTests extends AbstractControllerUnitTestCase
 	{
 		permitted = true
 		authenticated = true
-		
+
 		setupAndExecuteWhaleDetectionExtract()
-		
+
 		assertContainsAllLines(controller.response.contentAsString,
 			'''timestamp,station name,latitude,longitude,receiver ID,tag ID,species,uploader,transmitter ID,organisation,sensor value,sensor unit
 2011-05-17 02:54:00,Whale Station,-20.1234,76.02,VR2W-103377,A69-1303-6666,41110001 - Eubalaena australis (southern right whale),Joe Bloggs,A69-1303-6666,IMOS,,
@@ -55,7 +56,7 @@ class DetectionControllerTests extends AbstractControllerUnitTestCase
 	{
 		permitted = false
 		authenticated = true
-		
+
 		setupAndExecuteWhaleDetectionExtract()
 		def expected = '''timestamp,station name,latitude,longitude,receiver ID,tag ID,species,uploader,transmitter ID,organisation,sensor value,sensor unit
 2011-05-17 02:54:00,Whale Station,-20.1234,76.02,VR2W-103377,A69-1303-6666,41110001 - Eubalaena australis (southern right whale),Joe Bloggs,A69-1303-6666,IMOS,,
@@ -72,9 +73,9 @@ class DetectionControllerTests extends AbstractControllerUnitTestCase
 	{
 		permitted = false
 		authenticated = false
-		
+
 		setupAndExecuteWhaleDetectionExtract()
-		
+
 		def expected = '''timestamp,station name,latitude,longitude,receiver ID,tag ID,species,uploader,transmitter ID,organisation,sensor value,sensor unit
 2011-05-17 02:54:00,Whale Station,-20.12,76.01,VR2W-103377,A69-1303-6666,41110001 - Eubalaena australis (southern right whale),Joe Bloggs,A69-1303-6666,IMOS,,
 2011-05-17 02:54:02,Whale Station,-20.12,76.01,VR2W-103377,A69-1303-6666,41110001 - Eubalaena australis (southern right whale),Joe Bloggs,A69-1303-6666,IMOS,,
@@ -89,7 +90,7 @@ class DetectionControllerTests extends AbstractControllerUnitTestCase
 	private void setupAndExecuteWhaleDetectionExtract()
 	{
 		hasRole = false
-		
+
 		controller.params.filter = [receiverDeployment:[station:[installation:[project:[in:["name", "Whale"]]]]]]
 		controller.export()
 	}


### PR DESCRIPTION
This removes a dependency between tests that was causing an integration test failure on jenkins.
