### PR TITLE
The searchable file location is now in Config.groovy, as previously, the...

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -84,6 +84,10 @@ auditLog {
     }
 }
 
+compassConnection = new File(
+    "/tmp/search/${grailsEnv}"
+).absolutePath
+
 // set per-environment serverURL stem for creating absolute links
 environments
 {
@@ -116,6 +120,7 @@ environments
     }
 }
 
+
 /**
  * Instance specific customisation, clearly stolen from:
  * http://phatness.com/2010/03/how-to-externalize-your-grails-configuration/
@@ -145,6 +150,7 @@ try {
 catch (e) {
     println "Not loading external config"
 }
+
 
 def log4jConversionPattern = '%d [%t] [%X{username}] %-5p %c{1} - %m%n'
 

--- a/grails-app/conf/Searchable.groovy
+++ b/grails-app/conf/Searchable.groovy
@@ -124,28 +124,24 @@ searchable {
      * which means do a non-forking, otherwise "fork" is recommended
      */
     bulkIndexOnStartup = "fork"
-	
+
     /**
      * Should index locks be removed (if present) at startup?
      */
     releaseLocksOnStartup = true
-	
-    compassConnection = new File(
-        "/tmp/search/${grailsEnv}"
-    ).absolutePath
 }
 
 // per-environment settings
 environments {
 
-    test 
+    test
     {
-        searchable 
+        searchable
         {
             // Make sure things are in the index before tests are run (by doing
             // on main thread).
             bulkIndexOnStartup = true
-            
+
             // use faster in-memory index
             compassConnection = "ram://test-index"
         }


### PR DESCRIPTION
... config in Searchable.groovy was overwriting the chef configured value when deployed.
