### PR TITLE
A couple of SQL examples which demonstrate the performance of querying d...

### DIFF
--- a/scripts/sql/performance_proto/Guardfile
+++ b/scripts/sql/performance_proto/Guardfile
@@ -1,0 +1,3 @@
+guard :shell do
+  watch(%r{(.+\.sql)}) { |m| `psql -h localhost -d aatams_prod_copy < #{m[1]}` }
+end

--- a/scripts/sql/performance_proto/search_by_rxr.sql
+++ b/scripts/sql/performance_proto/search_by_rxr.sql
@@ -1,0 +1,22 @@
+select
+    model_name || '-' || serial_number as receiver_name,
+    deploymentdatetime_timestamp as "deployment timestamp",
+    valid_detection.timestamp as "detection timestamp",
+    recoverydatetime_timestamp as "recovery timestamp",
+    installation_station.name as "station name"
+      from device
+
+    join device_model on device.model_id = device_model.id
+    join receiver_deployment on device.id = receiver_deployment.receiver_id
+    join receiver_recovery on receiver_deployment.id = receiver_recovery.deployment_id
+    join valid_detection on model_name || '-' || serial_number = valid_detection.receiver_name
+    join installation_station on receiver_deployment.station_id = installation_station.id
+
+    where device.class = 'au.org.emii.aatams.Receiver'
+    and valid_detection.timestamp between deploymentdatetime_timestamp and recoverydatetime_timestamp
+
+    -- example filters
+    and model_name || '-' || serial_number = 'VR2W-101832'
+    and installation_station.name = 'MB74A'
+
+    limit 10;

--- a/scripts/sql/performance_proto/search_by_txr.sql
+++ b/scripts/sql/performance_proto/search_by_txr.sql
@@ -1,0 +1,19 @@
+select
+    sensor.transmitter_id,
+    releasedatetime_timestamp as "release timestamp",
+    common_name
+
+    from sensor
+    join surgery on sensor.tag_id = surgery.tag_id
+    join animal_release on surgery.release_id = animal_release.id
+    join animal on animal_release.animal_id = animal.id
+    join species on animal.species_id = species.id
+
+    join valid_detection on sensor.transmitter_id = valid_detection.transmitter_id
+
+    where valid_detection.timestamp >= releasedatetime_timestamp
+
+    -- example filters
+    and common_name = 'White Shark'
+
+    limit 10;


### PR DESCRIPTION
...etections and joining to deployments/releases on the fly.

`search_by_rxr.sql` executes in 0.150s
`search_by_txr.sql` executes in 0.020s
