### PR TITLE
Removed the vagrant/guest stuff from the restore script.

### DIFF
--- a/doc/BACKUP_AND_RESTORE.md
+++ b/doc/BACKUP_AND_RESTORE.md
@@ -1,3 +1,17 @@
-# Restoring the AATAMS database
+# Backup
+Backups are performed automatically, every second day.  There are two components to the backup:
+
+1. the postgresql database
+2. the uploaded files stored on the filesystem
+
+The backups can be retrieved from: `backups.aodn.org.au:/var/backup/backup`.
+
+# Restore
+## Restoring the PostgreSql database
 
 See [this restore script](restore_db.sh) for an example of how to restore the AATAMS database from backup.
+
+It assumes that you have an already provisioned database (i.e. by chef, and a node such as `4-nec-mel.emii.org.au`).
+
+## Restoring the uploaded files
+TODO

--- a/doc/restore_db.sh
+++ b/doc/restore_db.sh
@@ -3,36 +3,32 @@
 set -ex
 
 # Override these variables as required.
-NODE_NAME=${NODE_NAME:-"4-nec-mel.emii.org.au"}
 IGNORE_TABLE=${IGNORE_TABLE:-"databasechangelog|receiver_event|valid_detection|invalid_detection"}
 DUMP_FILE=${DUMP_FILE:-"/vagrant/aatams.dump"}
 
-guest_command() {
-    vagrant ssh $NODE_NAME -c "$@"
-}
-
-vagrant up $NODE_NAME
-
-if `guest_command "[ ! -f $DUMP_FILE ]"`; then
+if [ ! -f $DUMP_FILE ]; then
     echo "Backup dump file '$DUMP_FILE' not found!"
     exit 1
 fi
 
-DB_TOC=`guest_command mktemp`
+DB_TOC=`mktemp`
+chmod 644 $DB_TOC
 
-vagrant provision $NODE_NAME
-
-guest_command "sudo service tomcat7_aatams_rc start"
+# The app takes care of creating tables etc, via liquibase.
+sudo service tomcat7_aatams_rc start
 read -p "Press [Enter] key when app has started..."   # TODO: automate this?
 
-guest_command "sudo service tomcat7_aatams_rc stop"
+sudo service tomcat7_aatams_rc stop
 
-guest_command "sudo -u postgres pg_restore -l $DUMP_FILE | grep DATA | egrep -v '$IGNORE_TABLE' > $DB_TOC"
+# Create a table of contents which exludes our "ignore tables".
+sudo -u postgres pg_restore -l $DUMP_FILE | grep DATA | egrep -v $IGNORE_TABLE > $DB_TOC
 
-guest_command "sudo -u postgres time pg_restore -d aatams_rc --no-owner --use-list=$DB_TOC --disable-triggers $DUMP_FILE"
+# Load the data...
+sudo -u postgres time pg_restore -d aatams_rc --no-owner --use-list=$DB_TOC --disable-triggers $DUMP_FILE
 
-guest_command "sudo -u postgres psql -d aatams_rc -c \"update aatams.statistics set value=0 where key='numValidDetections';\""
+# ... and reset the stats.
+sudo -u postgres psql -d aatams_rc -c "update aatams.statistics set value=(select count(*) from aatams.valid_detection) where key='numValidDetections';"
 
-guest_command "sudo service tomcat7_aatams_rc start"
+sudo service tomcat7_aatams_rc start
 
-guest_command "rm -rf $DB_TOC"
+rm -rf $DB_TOC


### PR DESCRIPTION
Tidied up the backup/restore doc a little.

It's now assumed that the VM exists and has a provisioned DB, and that the script will run from within the VM (rather than via `vagrant ssh`).

The main reason for doing this is to enable @xhoenner to execute the script in an already running VM. This is because he doesn't have access to chef repo (therefore can't run the `vagrant up` etc commands).
