### PR TITLE
Clear errors on ReceiverRecovery before other validation is performed

### DIFF
--- a/grails-app/controllers/au/org/emii/aatams/ReceiverRecoveryController.groovy
+++ b/grails-app/controllers/au/org/emii/aatams/ReceiverRecoveryController.groovy
@@ -58,6 +58,8 @@ class ReceiverRecoveryController extends AbstractController
         def receiverRecoveryInstance = new ReceiverRecovery(params)
         receiverRecoveryInstance.deployment = deployment
 
+        receiverRecoveryInstance.clearErrors()
+
         deployment?.recovery = receiverRecoveryInstance
 
         if (deployment?.save(flush: true))


### PR DESCRIPTION
@jkburges Stack Overflow suggested this to clear that extra error. Seems to work.
