### PR TITLE
No longer paginating on detections and events list pages.

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -248,6 +248,7 @@ filter.count.max = 300000
 
 
 grails.gorm.default.list.max = 20
+grails.gorm.default.list.nonPaginatedMax = 100
 
 // Added by the Joda-Time plugin:
 grails.gorm.default.mapping = {

--- a/grails-app/controllers/au/org/emii/aatams/ReceiverEventController.groovy
+++ b/grails-app/controllers/au/org/emii/aatams/ReceiverEventController.groovy
@@ -5,26 +5,27 @@ import au.org.emii.aatams.report.ReportController
 class ReceiverEventController extends ReportController
 {
     def receiverEventExportService
-    
+
     static allowedMethods = [save: "POST", update: "POST", delete: "POST"]
 
     def index = {
         redirect(action: "list", params: params)
     }
 
-    def list = 
+    def list =
     {
+        params.max = params.max ?: grailsApplication.config.grails.gorm.default.list.nonPaginatedMax
         doList("receiverEvent")
     }
-    
+
     def export =
     {
         receiverEventExportService.generateReport(params, request, response)
     }
 
     def create = {
-        redirect(controller:"receiverDownloadFile", 
-                 action:"createEvents") 
+        redirect(controller:"receiverDownloadFile",
+                 action:"createEvents")
     }
 
     def save = {
@@ -66,7 +67,7 @@ class ReceiverEventController extends ReportController
             if (params.version) {
                 def version = params.version.toLong()
                 if (receiverEventInstance.version > version) {
-                    
+
                     receiverEventInstance.errors.rejectValue("version", "default.optimistic.locking.failure", [message(code: 'receiverEvent.label', default: 'ReceiverEvent')] as Object[], "Another user has updated this ReceiverEvent while you were editing")
                     render(view: "edit", model: [receiverEventInstance: receiverEventInstance])
                     return

--- a/grails-app/controllers/au/org/emii/aatams/detection/DetectionController.groovy
+++ b/grails-app/controllers/au/org/emii/aatams/detection/DetectionController.groovy
@@ -19,6 +19,7 @@ class DetectionController extends ReportController
 
     def list =
     {
+        params.max = params.max ?: grailsApplication.config.grails.gorm.default.list.nonPaginatedMax
         doList("detection")
     }
 

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -181,4 +181,4 @@ sensor.transmitterType.unique=Tag with this serial number already exists and has
 
 mail.notification.detection.new.subject=AATAMS detections for tags {0}
 
-nonPaginatedMax.warning=Showing maximum of {0} results only, adjust filter or download to different results.
+nonPaginatedMax.warning=Showing maximum of {0} records only. Download as CSV file to see all matching records.

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -180,3 +180,5 @@ sensor.transmitterType.unique=Tag with this serial number already exists and has
 #Property [{0}] of class [{1}] with value [{2}] must be unique
 
 mail.notification.detection.new.subject=AATAMS detections for tags {0}
+
+nonPaginatedMax.warning=Showing maximum of {0} results only, adjust filter or download to different results.

--- a/grails-app/taglib/au/org/emii/aatams/NonPaginatedTagLib.groovy
+++ b/grails-app/taglib/au/org/emii/aatams/NonPaginatedTagLib.groovy
@@ -1,0 +1,14 @@
+package au.org.emii.aatams
+
+class NonPaginatedTagLib {
+
+    def nonPaginatedWarning = {
+        out << """
+            <div class='paginateButtons'>
+                ${g.message(
+                    code: 'nonPaginatedMax.warning',
+                    args: [grailsApplication.config.grails.gorm.default.list.nonPaginatedMax]
+                )}
+            </div>"""
+    }
+}

--- a/grails-app/views/detection/list.gsp
+++ b/grails-app/views/detection/list.gsp
@@ -77,9 +77,7 @@
                     </tbody>
                 </table>
             </div>
-            <div class="paginateButtons">
-                <g:paginate total="${total}" params="${params}"/>
-            </div>
+            <g:nonPaginatedWarning />
         </div>
     </body>
 </html>

--- a/grails-app/views/receiverEvent/list.gsp
+++ b/grails-app/views/receiverEvent/list.gsp
@@ -1,4 +1,3 @@
-
 <%@ page import="au.org.emii.aatams.ReceiverEvent" %>
 <html>
     <head>
@@ -19,54 +18,52 @@
             <g:if test="${flash.message}">
             <div class="message">${flash.message}</div>
             </g:if>
-            
-            <g:listControlForm name="receiverEvent" formats="${['CSV']}" />       
-            
+
+            <g:listControlForm name="receiverEvent" formats="${['CSV']}" />
+
             <div class="list">
                 <table>
                     <thead>
                         <tr>
-                        
+
                             <th></th>
 
                             <g:sortableColumn property="timestamp" title="${message(code: 'receiverEvent.timestamp.label', default: 'Timestamp')}" params="${params}"/>
-                        
+
                             <g:sortableColumn property="description" title="${message(code: 'receiverEvent.description.label', default: 'Description')}" params="${params}"/>
-                        
+
                             <g:sortableColumn property="data" title="${message(code: 'receiverEvent.data.label', default: 'Data')}" params="${params}"/>
-                        
+
                             <g:sortableColumn property="units" title="${message(code: 'receiverEvent.units.label', default: 'Units')}" params="${params}"/>
-                        
+
                             <th><g:message code="receiverEvent.receiverDeployment.label" default="Receiver Deployment" /></th>
-                        
+
                         </tr>
                     </thead>
                     <tbody>
                     <g:each in="${entityList}" status="i" var="receiverEventInstance">
                         <tr class="${(i % 2) == 0 ? 'odd' : 'even'}">
-                        
+
                             <td class="rowButton"><g:link class="show" action="show" id="${receiverEventInstance.id}">.</g:link></td>
-                      
+
                             <td><g:formatDate date="${receiverEventInstance.timestamp}"
                                               format="yyyy-MM-dd'T'HH:mm:ssZ"
                                               timeZone='${TimeZone.getTimeZone("UTC")}'/></td>
-                        
+
                             <td>${fieldValue(bean: receiverEventInstance, field: "description")}</td>
-                        
+
                             <td>${fieldValue(bean: receiverEventInstance, field: "data")}</td>
-                        
+
                             <td>${fieldValue(bean: receiverEventInstance, field: "units")}</td>
-                        
+
                             <td><g:link controller="receiverDeployment" action="show" id="${receiverEventInstance?.receiverDeployment?.id}">${fieldValue(bean: receiverEventInstance, field: "receiverDeployment")}</g:link></td>
-                        
+
                         </tr>
                     </g:each>
                     </tbody>
                 </table>
             </div>
-            <div class="paginateButtons">
-                <g:paginate total="${total}" params="${params}"/>
-            </div>
+            <g:nonPaginatedWarning />
         </div>
     </body>
 </html>


### PR DESCRIPTION
Reliable pagination required sorting of records, which performs poorly.  Since pagination doesn't provide a lot of value in this context, it has been removed.