### PR TITLE
Fix for #180.

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -342,3 +342,28 @@ detection {
         }
     }
 }
+
+receiver_event {
+    extract {
+        receiver_event_view {
+            definition = """SELECT
+            timestamp,
+            receiver_project.name as project,
+            installation.name as installation,
+            installation_station.name as station,
+            receiver_name,
+            to_char((timestamp::timestamp with time zone) at time zone '00:00', 'YYYY-MM-DD HH24:MI:SS') as formatted_timestamp,
+            receiver_event.description,
+            data,
+            units
+
+            FROM receiver_event
+            JOIN receiver_deployment ON receiver_event.receiver_deployment_id = receiver_deployment.id
+            JOIN device receiver ON receiver_deployment.receiver_id = receiver.id
+            JOIN device_model ON receiver.model_id = device_model.id
+            JOIN installation_station ON receiver_deployment.station_id = installation_station.id
+            JOIN installation ON installation_station.installation_id = installation.id
+            JOIN project receiver_project ON installation.project_id = receiver_project.id;"""
+        }
+    }
+}

--- a/grails-app/migrations/changelog.groovy
+++ b/grails-app/migrations/changelog.groovy
@@ -12,4 +12,5 @@ databaseChangeLog = {
     include file: 'detection_query_optimisation.groovy'
     include file: 'remove_detection_matview.groovy'
     include file: 'protected_species_flag.groovy'
+    include file: 'receiver_event_view.groovy'
 }

--- a/grails-app/migrations/receiver_event_view.groovy
+++ b/grails-app/migrations/receiver_event_view.groovy
@@ -1,0 +1,10 @@
+databaseChangeLog = {
+    changeSet(author: "jburgess", id: "1423026565000-01") {
+
+        grailsChange {
+            change {
+                sql.execute(String.valueOf("create or replace view receiver_event_view as ${application.config.receiver_event.extract.receiver_event_view.definition}"))
+            }
+        }
+    }
+}

--- a/grails-app/services/au/org/emii/aatams/detection/JdbcTemplateVueDetectionFileProcessorService.groovy
+++ b/grails-app/services/au/org/emii/aatams/detection/JdbcTemplateVueDetectionFileProcessorService.groovy
@@ -134,7 +134,7 @@ class JdbcTemplateVueDetectionFileProcessorService extends VueDetectionFileProce
         def sql = Sql.newInstance(dataSource)
 
         // Update statistics.
-        def provDetsCount = sql.firstRow(String.valueOf("select count(*) from ${QueryBuilder.getViewName()} where provisional = true;")).count
+        def provDetsCount = sql.firstRow(String.valueOf("select count(*) from ${new DetectionQueryBuilder().getViewName()} where provisional = true;")).count
         def numValidDets = Statistics.findByKey("numValidDetections")
         numValidDets.value += provDetsCount
 

--- a/grails-app/services/au/org/emii/aatams/export/AbstractStreamingExporterService.groovy
+++ b/grails-app/services/au/org/emii/aatams/export/AbstractStreamingExporterService.groovy
@@ -1,5 +1,7 @@
 package au.org.emii.aatams.export
 
+import au.org.emii.aatams.sql.Sql
+
 import java.util.zip.GZIPOutputStream
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
@@ -9,6 +11,8 @@ import org.codehaus.groovy.grails.commons.ConfigurationHolder
 
 abstract class AbstractStreamingExporterService
 {
+    def dataSource
+
     protected abstract void writeCsvHeader(OutputStream out)
     protected abstract def writeCsvRow(resultList, OutputStream out)
     protected def applyEmbargo(results, params) { return results }
@@ -73,6 +77,10 @@ abstract class AbstractStreamingExporterService
 
     protected void writeCsvData(final params, OutputStream out)
     {
+        params.sql = new Sql(dataSource)
+        params.sql.fetchSize = getFetchSize()
+        params.sql.autoCommit = false
+
         indicateExportStart(params)
         writeCsvHeader(out)
 

--- a/src/groovy/au/org/emii/aatams/QueryBuilder.groovy
+++ b/src/groovy/au/org/emii/aatams/QueryBuilder.groovy
@@ -1,4 +1,4 @@
-package au.org.emii.aatams.detection
+package au.org.emii.aatams
 
 import org.jooq.*
 import org.jooq.conf.ParamType
@@ -8,9 +8,11 @@ import org.apache.log4j.Logger
 
 import static org.jooq.impl.DSL.*
 
-class QueryBuilder {
+abstract class QueryBuilder {
 
     def log = Logger.getLogger(QueryBuilder.class)
+
+    abstract String getViewName(filterParams)
 
     def constructCountQuery(filterParams) {
         filterParams.count = true
@@ -32,16 +34,6 @@ class QueryBuilder {
         log.debug("query: ${query.getSQL(org.jooq.conf.ParamType.INLINED)}")
 
         return query
-    }
-
-    static String getViewName(filterParams) {
-        return hasSpeciesFilter(filterParams) ? "detection_by_species_view" : "detection_view"
-    }
-
-    static boolean hasSpeciesFilter(filterParams) {
-        def speciesInFilter = filterParams?.filter?.surgeries?.release?.animal?.species?.in
-
-        return speciesInFilter && (speciesInFilter.size() == 2) && (!speciesInFilter[1].isEmpty())
     }
 
     private void addInClauses(query, filterParams) {
@@ -74,7 +66,7 @@ class QueryBuilder {
         }
     }
 
-    private List delimitedFilterValuesToList(delimVals) {
+    List delimitedFilterValuesToList(delimVals) {
         return delimVals.tokenize("|").collect { it.trim() }.grep { it }
     }
 }

--- a/src/groovy/au/org/emii/aatams/ReceiverEventQueryBuilder.groovy
+++ b/src/groovy/au/org/emii/aatams/ReceiverEventQueryBuilder.groovy
@@ -1,0 +1,7 @@
+package au.org.emii.aatams
+
+class ReceiverEventQueryBuilder extends QueryBuilder {
+    String getViewName(filterParams) {
+        return "receiver_event_view"
+    }
+}

--- a/src/groovy/au/org/emii/aatams/detection/DetectionQueryBuilder.groovy
+++ b/src/groovy/au/org/emii/aatams/detection/DetectionQueryBuilder.groovy
@@ -1,0 +1,15 @@
+package au.org.emii.aatams.detection
+
+import au.org.emii.aatams.QueryBuilder
+
+class DetectionQueryBuilder extends QueryBuilder {
+    String getViewName(filterParams) {
+        return hasSpeciesFilter(filterParams) ? "detection_by_species_view" : "detection_view"
+    }
+
+    boolean hasSpeciesFilter(filterParams) {
+        def speciesInFilter = filterParams?.filter?.surgeries?.release?.animal?.species?.in
+
+        return speciesInFilter && (speciesInFilter.size() == 2) && (!speciesInFilter[1].isEmpty())
+    }
+}

--- a/src/groovy/au/org/emii/aatams/test/TestUtils.groovy
+++ b/src/groovy/au/org/emii/aatams/test/TestUtils.groovy
@@ -25,6 +25,12 @@ class TestUtils
         }
     }
 
+    static void createReceiverEventView(dataSource) {
+        def sql = new Sql(dataSource)
+
+        sql.execute(String.valueOf("create or replace view receiver_event_view as ${ConfigurationHolder.config.receiver_event.extract.receiver_event_view.definition}"))
+    }
+
     enum VisibilityLevel {
         VISIBLE,
         VISIBLE_BUT_SANITISED,

--- a/test/integration/au/org/emii/aatams/ReceiverEventControllerTests.groovy
+++ b/test/integration/au/org/emii/aatams/ReceiverEventControllerTests.groovy
@@ -1,13 +1,19 @@
 package au.org.emii.aatams
 
 import au.org.emii.aatams.test.AbstractControllerUnitTestCase
+import au.org.emii.aatams.test.TestUtils
+
 import grails.test.*
 
 class ReceiverEventControllerTests extends AbstractControllerUnitTestCase
 {
+    def dataSource
+
     protected void setUp()
     {
         super.setUp()
+
+        TestUtils.createReceiverEventView(dataSource)
 
         controller.params.format = "CSV"
     }
@@ -19,6 +25,6 @@ class ReceiverEventControllerTests extends AbstractControllerUnitTestCase
 
     void testExecuteReceiverEventByProject()
     {
-        assertExport([receiverDeployment: [station: [installation: [project: [eq: ["name", "Tuna"]]]]]], "testExecuteReceiverEventByProject")
+        assertExport([receiverDeployment: [station: [installation: [project: [in: ["name", "Tuna"]]]]]], "testExecuteReceiverEventByProject")
     }
 }

--- a/test/integration/au/org/emii/aatams/detection/JdbcTemplateVueDetectionFileProcessorServiceIntegrationTests.groovy
+++ b/test/integration/au/org/emii/aatams/detection/JdbcTemplateVueDetectionFileProcessorServiceIntegrationTests.groovy
@@ -89,7 +89,7 @@ class JdbcTemplateVueDetectionFileProcessorServiceIntegrationTests extends Abstr
     }
 
     private def getDetectionViewCount() {
-        return sql.firstRow(String.valueOf("select count(*) from ${QueryBuilder.getViewName()};")).count
+        return sql.firstRow(String.valueOf("select count(*) from ${new DetectionQueryBuilder().getViewName()};")).count
     }
 
     private def getValidDetectionCount() {

--- a/test/unit/au/org/emii/aatams/detection/DetectionQueryBuilderTests.groovy
+++ b/test/unit/au/org/emii/aatams/detection/DetectionQueryBuilderTests.groovy
@@ -9,7 +9,7 @@ import grails.test.*
 
 import org.jooq.conf.ParamType
 
-class QueryBuilderTests extends GrailsUnitTestCase
+class DetectionQueryBuilderTests extends GrailsUnitTestCase
 {
     void testConstructQueryNoFilterParams() {
         assertQueryFromFilterEquals('', [:])
@@ -97,40 +97,40 @@ class QueryBuilderTests extends GrailsUnitTestCase
 
     void testConstructCountQuery() {
         assertEquals(
-            "select count(*) from ${QueryBuilder.getViewName()}".trim(),
-            new QueryBuilder().constructCountQuery([:]).getSQL(ParamType.INLINED).trim()
+            "select count(*) from ${new DetectionQueryBuilder().getViewName()}".trim(),
+            new DetectionQueryBuilder().constructCountQuery([:]).getSQL(ParamType.INLINED).trim()
         )
     }
 
     void testGetViewNameNoFilter() {
-        assertEquals("detection_view", QueryBuilder.getViewName([:]))
+        assertEquals("detection_view", new DetectionQueryBuilder().getViewName([:]))
     }
 
     void testGetViewNameOneProjectFilter() {
         assertEquals(
             "detection_view",
-            QueryBuilder.getViewName([filter: [receiverDeployment:[station:[installation:[project:[in: ["name", "Whales | "]]]]]]])
+            new DetectionQueryBuilder().getViewName([filter: [receiverDeployment:[station:[installation:[project:[in: ["name", "Whales | "]]]]]]])
         )
     }
 
     void testGetViewNameOneSpeciesFilter() {
         assertEquals(
             "detection_by_species_view",
-            QueryBuilder.getViewName([filter: [surgeries:[release:[animal:[species:[in:["spcode", "12345 | "]]]]]]])
+            new DetectionQueryBuilder().getViewName([filter: [surgeries:[release:[animal:[species:[in:["spcode", "12345 | "]]]]]]])
         )
     }
 
     void testGetViewNameEmptySpeciesFilter() {
         assertEquals(
             "detection_view",
-            QueryBuilder.getViewName([filter: [surgeries:[release:[animal:[species:[in:["spcode", ""]]]]]]])
+            new DetectionQueryBuilder().getViewName([filter: [surgeries:[release:[animal:[species:[in:["spcode", ""]]]]]]])
         )
     }
 
     void testGetViewNameOneSpeciesOneProjectFilter() {
         assertEquals(
             "detection_by_species_view",
-            QueryBuilder.getViewName(
+            new DetectionQueryBuilder().getViewName(
                 [filter: [receiverDeployment:[station:[installation:[project:[in: ["name", "Whales | "]]]]],
                           surgeries:[release:[animal:[species:[in:["spcode", "12345 | "]]]]]]]
             )
@@ -139,8 +139,8 @@ class QueryBuilderTests extends GrailsUnitTestCase
 
     def assertQueryFromFilterEquals(expectedSql, filter) {
         assertEquals(
-            "select * from ${QueryBuilder.getViewName()} ${expectedSql}".trim(),
-            new QueryBuilder().constructQuery(filter).getSQL(ParamType.INLINED).trim()
+            "select * from ${new DetectionQueryBuilder().getViewName()} ${expectedSql}".trim(),
+            new DetectionQueryBuilder().constructQuery(filter).getSQL(ParamType.INLINED).trim()
         )
     }
 }


### PR DESCRIPTION
Receiver events are now exported in the same manner as detections (i.e. by building SQL directly).  This is to take advantage of cursors (rather than paging).

Previously, the `QueryService` was being used, which in turn uses hibernate criteria.  Since the offset/limit/paging stuff has been taken out of the `AbstractStreamingExporterService`, this was causing an attempt to load the whole export in to memory at once, thereby using it all up.