### PR TITLE
Remove old write permissions

### DIFF
--- a/grails-app/migrations/regenerate_all_permissions.groovy
+++ b/grails-app/migrations/regenerate_all_permissions.groovy
@@ -15,4 +15,10 @@ databaseChangeLog = {
             }
         }
     }
+
+    changeSet(author: "dnahodil", id: "1424388299000-01") {
+        delete(tableName: 'sec_user_permissions') {
+            where "permissions_string like 'project:%:write'"
+        }
+    }
 }

--- a/grails-app/views/organisationProject/edit.gsp
+++ b/grails-app/views/organisationProject/edit.gsp
@@ -30,7 +30,7 @@
                 <div class="dialog">
                     <table>
                         <tbody>
-                        
+
                             <tr class="prop">
                                 <td valign="top" class="name">
                                   <label class="compulsory" for="organisation"><g:message code="organisationProject.organisation.label" default="Organisation" /></label>
@@ -40,7 +40,7 @@
 
                                 </td>
                             </tr>
-                        
+
                             <tr class="prop">
                                 <td valign="top" class="name">
                                   <label class="compulsory" for="project"><g:message code="organisationProject.project.label" default="Project" /></label>
@@ -50,7 +50,7 @@
 
                                 </td>
                             </tr>
-                        
+
                         </tbody>
                     </table>
                 </div>

--- a/grails-app/views/organisationProject/edit.gsp
+++ b/grails-app/views/organisationProject/edit.gsp
@@ -56,7 +56,7 @@
                 </div>
                 <div class="buttons">
                     <g:hiddenField name="projectId" value="${organisationProjectInstance?.project?.id}" />
-                    <shiro:hasPermission permission="project:${organisationProjectInstance?.project?.id}:write">
+                    <shiro:hasPermission permission="project:${organisationProjectInstance?.project?.id}:edit">
                       <span class="button"><g:actionSubmit class="edit" action="edit" value="${message(code: 'default.button.edit.label', default: 'Edit')}" /></span>
                       <span class="button"><g:actionSubmit class="delete" action="delete" value="${message(code: 'default.button.delete.label', default: 'Delete')}" onclick="return confirm('${message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');" /></span>
                     </shiro:hasPermission>

--- a/grails-app/views/organisationProject/show.gsp
+++ b/grails-app/views/organisationProject/show.gsp
@@ -21,21 +21,21 @@
             <div class="dialog">
                 <table>
                     <tbody>
-                    
+
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="organisationProject.organisation.label" default="Organisation" /></td>
-                            
+
                             <td valign="top" class="value"><g:link controller="organisation" action="show" id="${organisationProjectInstance?.organisation?.id}">${organisationProjectInstance?.organisation?.encodeAsHTML()}</g:link></td>
-                            
+
                         </tr>
-                    
+
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="organisationProject.project.label" default="Project" /></td>
-                            
+
                             <td valign="top" class="value"><g:link controller="project" action="show" id="${organisationProjectInstance?.project?.id}">${organisationProjectInstance?.project?.encodeAsHTML()}</g:link></td>
-                            
+
                         </tr>
-                    
+
                     </tbody>
                 </table>
             </div>

--- a/grails-app/views/organisationProject/show.gsp
+++ b/grails-app/views/organisationProject/show.gsp
@@ -43,7 +43,7 @@
                 <g:form>
                     <g:hiddenField name="id" value="${organisationProjectInstance?.id}" />
                     <g:hiddenField name="projectId" value="${organisationProjectInstance?.project?.id}" />
-                    <shiro:hasPermission permission="project:${organisationProjectInstance?.project?.id}:write">
+                    <shiro:hasPermission permission="project:${organisationProjectInstance?.project?.id}:edit">
                       <span class="button"><g:actionSubmit class="edit" action="edit" value="${message(code: 'default.button.edit.label', default: 'Edit')}" /></span>
                       <span class="button"><g:actionSubmit class="delete" action="delete" value="${message(code: 'default.button.delete.label', default: 'Delete')}" onclick="return confirm('${message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');" /></span>
                     </shiro:hasPermission>

--- a/grails-app/views/person/show.gsp
+++ b/grails-app/views/person/show.gsp
@@ -23,14 +23,14 @@
             <div class="dialog">
                 <table>
                     <tbody>
-                    
+
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="person.name.label" default="Name" /></td>
-                            
+
                             <td valign="top" class="value">${fieldValue(bean: personInstance, field: "name")}</td>
-                            
+
                         </tr>
-                    
+
                         <shiro:hasRole name="SysAdmin">
                           <tr class="prop">
                               <td valign="top" class="name"><g:message code="secUser.username.label" default="Username" /></td>
@@ -42,13 +42,13 @@
 
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="person.organisation.label" default="Organisation" /></td>
-                            
+
                             <td valign="top" class="value">
                               <g:link controller="organisation" action="show" id="${personInstance?.organisation?.id}">${personInstance?.organisation?.encodeAsHTML()}</g:link>
                             </td>
-                            
+
                         </tr>
-                        
+
                         <shiro:user>
                           <tr class="prop">
                               <td valign="top" class="name"><g:message code="person.phoneNumber.label" default="Phone Number" /></td>
@@ -64,10 +64,10 @@
 
                           </tr>
                         </shiro:user>
-                    
+
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="person.projectRoles.label" default="Projects" /></td>
-                            
+
                             <td valign="top" style="text-align: left;" class="value">
                                 <ul>
                                 <g:each in="${personInstance.projectRoles?.project}" var="p">
@@ -75,9 +75,9 @@
                                 </g:each>
                                 </ul>
                             </td>
-                            
+
                         </tr>
-                        
+
                         <shiro:hasRole name="SysAdmin">
                           <tr class="prop">
                               <td valign="top" class="name"><g:message code="person.status.label" default="Status" /></td>
@@ -86,28 +86,28 @@
 
                           </tr>
                         </shiro:hasRole>
-                        
+
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="person.defaultTimeZone.label" default="Default Time Zone" /></td>
 
                             <td valign="top" class="value">${personInstance?.defaultTimeZone?.encodeAsHTML()}</td>
 
                         </tr>
-                    
+
                     </tbody>
                 </table>
             </div>
             <div class="buttons">
                 <g:form>
                     <g:hiddenField name="id" value="${personInstance?.id}" />
-                    
+
                     <!-- This button should only be shown if permitted -->
 <%--                    <shiro:hasPermission permission="${personInstance?.id}:write">--%>
                       <g:if test="${canEdit}">
                         <span class="button"><g:actionSubmit class="edit" action="edit" value="${message(code: 'default.button.edit.label', default: 'Edit')}" /></span>
                       </g:if>
 <%--                    </shiro:hasPermission>--%>
-                    
+
                     <shiro:hasRole name="SysAdmin">
                       <span class="button"><g:actionSubmit class="delete" action="delete" value="${message(code: 'default.button.delete.label', default: 'Delete')}" onclick="return confirm('${message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');" /></span>
                     </shiro:hasRole>

--- a/grails-app/views/project/edit.gsp
+++ b/grails-app/views/project/edit.gsp
@@ -57,7 +57,7 @@
                                       <g:each in="${projectInstance.organisationProjects}" var="op">
                                         <tr>
                                           <td class="rowButton"><g:link class="show" controller="organisationProject" action="show" id="${op?.id}">.</g:link></td>
-                                          <shiro:hasPermission permission="project:${projectInstance?.id}:write">
+                                          <shiro:hasPermission permission="project:${projectInstance?.id}:edit">
                                             <td class="rowButton">
                                               <g:link controller="organisationProject"
                                                       action="delete"
@@ -100,7 +100,7 @@
                                     <thead>
                                       <tr>
                                         <th/>
-                                        <shiro:hasPermission permission="project:${projectInstance?.id}:write">
+                                        <shiro:hasPermission permission="project:${projectInstance?.id}:edit">
                                           <th/>
                                         </shiro:hasPermission>
                                         <th>Name</th>
@@ -112,7 +112,7 @@
                                       <g:each in="${projectInstance?.projectRoles?}" var="p">
                                         <tr>
                                           <td class="rowButton"><g:link class="show" controller="projectRole" action="show" id="${p?.id}">.</g:link></td>
-                                          <shiro:hasPermission permission="project:${projectInstance?.id}:write">
+                                          <shiro:hasPermission permission="project:${projectInstance?.id}:edit">
                                             <td class="rowButton">
                                               <g:link controller="projectRole"
                                                       action="delete"
@@ -178,7 +178,7 @@
                     </table>
                 </div>
                 <div class="buttons">
-                    <shiro:hasPermission permission="${'project:' + projectInstance?.id + ':write'}">
+                    <shiro:hasPermission permission="${'project:' + projectInstance?.id + ':edit'}">
                       <span class="button"><g:actionSubmit class="save" action="update" value="${message(code: 'default.button.update.label', default: 'Update')}" /></span>
                     </shiro:hasPermission>
 

--- a/grails-app/views/projectRole/edit.gsp
+++ b/grails-app/views/projectRole/edit.gsp
@@ -30,7 +30,7 @@
                 <div class="dialog">
                     <table>
                         <tbody>
-                        
+
                             <tr class="prop">
                                 <td valign="top" class="name">
                                   <label class="compulsory" for="access"><g:message code="projectRole.access.label" default="Access" /></label>
@@ -40,7 +40,7 @@
 
                                 </td>
                             </tr>
-                        
+
                             <tr class="prop">
                                 <td valign="top" class="name">
                                   <label class="compulsory" for="person"><g:message code="projectRole.person.label" default="Person" /></label>
@@ -50,7 +50,7 @@
 
                                 </td>
                             </tr>
-                        
+
                             <tr class="prop">
                                 <td valign="top" class="name">
                                   <label class="compulsory" for="project"><g:message code="projectRole.project.label" default="Project" /></label>
@@ -60,7 +60,7 @@
 
                                 </td>
                             </tr>
-                        
+
                             <tr class="prop">
                                 <td valign="top" class="name">
                                   <label class="compulsory" for="roleType"><g:message code="projectRole.roleType.label" default="Role Type" /></label>
@@ -70,7 +70,7 @@
 
                                 </td>
                             </tr>
-                        
+
                         </tbody>
                     </table>
                 </div>

--- a/grails-app/views/projectRole/edit.gsp
+++ b/grails-app/views/projectRole/edit.gsp
@@ -76,7 +76,7 @@
                 </div>
                 <div class="buttons">
                     <g:hiddenField name="projectId" value="${projectRoleInstance?.project?.id}" />
-                    <shiro:hasPermission permission="project:${projectRoleInstance?.project?.id}:write">
+                    <shiro:hasPermission permission="project:${projectRoleInstance?.project?.id}:edit">
                       <span class="button"><g:actionSubmit class="save" action="update" value="${message(code: 'default.button.update.label', default: 'Update')}" /></span>
                       <span class="button"><g:actionSubmit class="delete" action="delete" value="${message(code: 'default.button.delete.label', default: 'Delete')}" onclick="return confirm('${message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');" /></span>
                     </shiro:hasPermission>

--- a/grails-app/views/projectRole/show.gsp
+++ b/grails-app/views/projectRole/show.gsp
@@ -21,35 +21,35 @@
             <div class="dialog">
                 <table>
                     <tbody>
-                    
+
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="projectRole.access.label" default="Access" /></td>
-                            
+
                             <td valign="top" class="value">${projectRoleInstance?.access?.encodeAsHTML()}</td>
-                            
+
                         </tr>
-                    
+
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="projectRole.person.label" default="Person" /></td>
-                            
+
                             <td valign="top" class="value"><g:link controller="person" action="show" id="${projectRoleInstance?.person?.id}">${projectRoleInstance?.person?.encodeAsHTML()}</g:link></td>
-                            
+
                         </tr>
-                    
+
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="projectRole.project.label" default="Project" /></td>
-                            
+
                             <td valign="top" class="value"><g:link controller="project" action="show" id="${projectRoleInstance?.project?.id}">${projectRoleInstance?.project?.encodeAsHTML()}</g:link></td>
-                            
+
                         </tr>
-                    
+
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="projectRole.roleType.label" default="Role Type" /></td>
-                            
+
                             <td valign="top" class="value"><g:link controller="projectRoleType" action="show" id="${projectRoleInstance?.roleType?.id}">${projectRoleInstance?.roleType?.encodeAsHTML()}</g:link></td>
-                            
+
                         </tr>
-                    
+
                     </tbody>
                 </table>
             </div>

--- a/grails-app/views/receiverRecovery/_recoveryList.gsp
+++ b/grails-app/views/receiverRecovery/_recoveryList.gsp
@@ -1,4 +1,4 @@
-<div class="recoveryTable">                
+<div class="recoveryTable">
     <div class="list">
         <table class="${clazz}">
             <thead>
@@ -9,100 +9,100 @@
             </thead>
             <thead>
                 <tr>
-                
+
                     <td/>
                     <g:column property="deploymentDateTime" title="${message(code: 'receiverDeployment.deploymentDateTime.label', default: 'Deployment Date')}"
                               params="${params}" sortable="${sortable}" />
-    
+
                     <g:column property="station.installation" title="${message(code: 'receiverDeployment.installation.label', default: 'Installation')}"
                                       params="${params}" sortable="${sortable}" />
-                                      
-                
+
+
                     <g:column property="station.name" title="${message(code: 'receiverDeployment.station.label', default: 'Station')}"
                                       params="${params}" sortable="${sortable}" />
-                
+
                     <g:if test="${!hideColumns?.contains('deploymentLocation')}">
                         <th><g:message code="receiverDeployment.station.location.label" default="Location" /></th>
                     </g:if>
-                
+
                     <!--  Bit of a hack to sort by serial number, but it seems that for all intents and purposes, this will give the
                           same result as sorting by name (cannot sort by name, because it is a transient property. -->
                     <g:if test="${!hideColumns?.contains('receiver')}">
                         <g:column property="receiver.serialNumber" title="${message(code: 'receiverDeployment.receiver.label', default: 'Receiver')}"
                                           params="${params}" sortable="${sortable}" />
                     </g:if>
-                
+
                     <th><g:message code="receiverDeployment.station.depth.label" default="Depth" /></th>
-                
+
                     <!-- New/edit column -->
                     <th><g:message code="receiverRecovery.label" default="Recovery" /></th>
-                    
+
                     <g:column property="recovery.recoverer.person.name" title="${message(code: 'receiverRecovery.recoverer.label', default: 'Recovered By')}"
                                       params="${params}" sortable="${sortable}" />
-    
+
                     <g:if test="${!hideColumns?.contains('recoveryLocation')}">
                         <th><g:message code="receiverRecovery.location" default="Location" /></th>
                     </g:if>
-                
+
                     <g:column property="recovery.recoveryDateTime" title="${message(code: 'receiverRecovery.recoveryDateTime.label', default: 'Recovery Date')}"
                                       params="${params}" sortable="${sortable}" />
-                
+
                     <g:column property="recovery.status" title="${message(code: 'receiverRecovery.status.label', default: 'Status')}"
                                       params="${params}" sortable="${sortable}" />
-                
+
                 </tr>
             </thead>
             <tbody>
             <g:each in="${entityList}" status="i" var="receiverDeployment">
                 <tr class="${(i % 2) == 0 ? 'odd' : 'even'}">
-    
+
                     <td class="rowButton"><g:link class="show" controller="receiverDeployment" action="show" id="${receiverDeployment.id}">.</g:link></td>
-            
+
                     <td><joda:format value="${receiverDeployment.deploymentDateTime}" /></td>
-                
+
                     <td><g:link controller="installation" action="show" id="${receiverDeployment?.station?.installation?.id}">${receiverDeployment?.station?.installation}</g:link></td>
-    
+
                     <td><g:link controller="installationStation" action="show" id="${receiverDeployment?.station?.id}">${receiverDeployment?.station}</g:link></td>
-                
+
                     <g:if test="${!hideColumns?.contains('deploymentLocation')}">
                         <td>
                           <g:point name="scrambledLocation"
                                    value="${receiverDeployment?.station?.scrambledLocation}" />
                         </td>
                     </g:if>
-                    
+
                     <g:if test="${!hideColumns?.contains('receiver')}">
                         <td><g:link action="receiver" controller="receiver" action="show" id="${receiverDeployment?.receiver?.id}">${receiverDeployment?.receiver}</g:link></td>
                     </g:if>
-    
+
                     <td>${fieldValue(bean: receiverDeployment, field: "depthBelowSurfaceM")}</td>
-    
+
                     <td class="rowButton">
                       <g:if test="${receiverDeployment?.recovery == null}">
                         <shiro:hasPermission permission="project:${projectId:receiverDeployment?.station?.installation?.project?.id}:write">
-                          <g:link class="create" controller="receiverRecovery" action="create" 
+                          <g:link class="create" controller="receiverRecovery" action="create"
                                   params="[deploymentId:receiverDeployment.id, projectId:receiverDeployment?.station?.installation?.project?.id]"></g:link>
-                        </shiro:hasPermission>  
+                        </shiro:hasPermission>
                       </g:if>
                       <g:else>
                         <g:link class="show" controller="receiverRecovery" action="show" id="${receiverDeployment?.recovery?.id}"></g:link>
                       </g:else>
                     </td>
-                    
+
                     <td>${fieldValue(bean: receiverDeployment?.recovery?.recoverer, field: "person")}</td>
-    
+
                     <g:if test="${!hideColumns?.contains('recoveryLocation')}">
                         <td>
                           <g:point name="scrambledLocation"
                                    value="${receiverDeployment?.recovery?.scrambledLocation}" />
                         </td>
                     </g:if>
-    
+
                     <td><joda:format value="${receiverDeployment?.recovery?.recoveryDateTime}" /></td>
-    
+
                     <td>${fieldValue(bean: receiverDeployment?.recovery, field: "status")}</td>
-    
-                
+
+
                 </tr>
             </g:each>
             </tbody>

--- a/grails-app/views/receiverRecovery/_recoveryList.gsp
+++ b/grails-app/views/receiverRecovery/_recoveryList.gsp
@@ -79,7 +79,7 @@
 
                     <td class="rowButton">
                       <g:if test="${receiverDeployment?.recovery == null}">
-                        <shiro:hasPermission permission="project:${projectId:receiverDeployment?.station?.installation?.project?.id}:write">
+                        <shiro:hasPermission permission="project:${projectId:receiverDeployment?.station?.installation?.project?.id}:edit_children">
                           <g:link class="create" controller="receiverRecovery" action="create"
                                   params="[deploymentId:receiverDeployment.id, projectId:receiverDeployment?.station?.installation?.project?.id]"></g:link>
                         </shiro:hasPermission>

--- a/grails-app/views/sensor/edit.gsp
+++ b/grails-app/views/sensor/edit.gsp
@@ -96,7 +96,7 @@
                 </div>
                 <div class="buttons">
                     <g:hiddenField name="projectId" value="${sensorInstance?.project?.id}" />
-                    <shiro:hasPermission permission="project:${sensorInstance?.project?.id}:write">
+                    <shiro:hasPermission permission="project:${sensorInstance?.project?.id}:edit_children">
                       <span class="button"><g:actionSubmit class="save" action="update" value="${message(code: 'default.button.update.label', default: 'Update')}" /></span>
                       <span class="button"><g:actionSubmit class="delete" action="delete" value="${message(code: 'default.button.delete.label', default: 'Delete')}" onclick="return confirm('${message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');" /></span>
                     </shiro:hasPermission>

--- a/grails-app/views/sensor/show.gsp
+++ b/grails-app/views/sensor/show.gsp
@@ -23,49 +23,49 @@
             <div class="dialog">
                 <table>
                     <tbody>
-                    
+
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="sensor.transmitterType.label" default="Transmitter Type" /></td>
-                            
+
                             <td valign="top" class="value"><g:link controller="transmitterType" action="show" id="${sensorInstance?.transmitterType?.id}">${sensorInstance?.transmitterType?.encodeAsHTML()}</g:link></td>
-                            
+
                         </tr>
 
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="sensor.pingCode.label" default="Ping Code" /></td>
-                            
+
                             <td valign="top" class="value">${sensorInstance?.pingCode}</td>
-                            
+
                         </tr>
-                    
+
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="sensor.slope.label" default="Slope" /></td>
-                            
+
                             <td valign="top" class="value">${fieldValue(bean: sensorInstance, field: "slope")}</td>
-                            
+
                         </tr>
-                    
+
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="sensor.intercept.label" default="Intercept" /></td>
-                            
+
                             <td valign="top" class="value">${fieldValue(bean: sensorInstance, field: "intercept")}</td>
-                            
+
                         </tr>
-                    
+
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="sensor.unit.label" default="Unit" /></td>
-                            
+
                             <td valign="top" class="value">${fieldValue(bean: sensorInstance, field: "unit")}</td>
-                            
+
                         </tr>
-                    
+
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="sensor.status.label" default="Status" /></td>
-                            
+
                             <td valign="top" class="value"><g:link controller="deviceStatus" action="show" id="${sensorInstance?.status?.id}">${sensorInstance?.status?.encodeAsHTML()}</g:link></td>
-                            
+
                         </tr>
-                    
+
                     </tbody>
                 </table>
             </div>

--- a/grails-app/views/sensor/show.gsp
+++ b/grails-app/views/sensor/show.gsp
@@ -73,7 +73,7 @@
                 <g:form>
                     <g:hiddenField name="id" value="${sensorInstance?.id}" />
                     <g:hiddenField name="projectId" value="${sensorInstance?.project?.id}" />
-                    <shiro:hasPermission permission="project:${sensorInstance?.project?.id}:write">
+                    <shiro:hasPermission permission="project:${sensorInstance?.project?.id}:edit_children">
                       <span class="button"><g:actionSubmit class="edit" action="edit" value="${message(code: 'default.button.edit.label', default: 'Edit')}" /></span>
                       <span class="button"><g:actionSubmit class="delete" action="delete" value="${message(code: 'default.button.delete.label', default: 'Delete')}" onclick="return confirm('${message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');" /></span>
                     </shiro:hasPermission>

--- a/grails-app/views/surgery/edit.gsp
+++ b/grails-app/views/surgery/edit.gsp
@@ -98,7 +98,7 @@
                 </div>
                 <div class="buttons">
                     <g:hiddenField name="projectId" value="${surgeryInstance?.release?.project?.id}" />
-                    <shiro:hasPermission permission="project:${surgeryInstance?.release?.project?.id}:write">
+                    <shiro:hasPermission permission="project:${surgeryInstance?.release?.project?.id}:edit_children">
                       <span class="button"><g:actionSubmit class="save" action="update" value="${message(code: 'default.button.update.label', default: 'Update')}" /></span>
                       <span class="button"><g:actionSubmit class="delete" action="delete" value="${message(code: 'default.button.delete.label', default: 'Delete')}" onclick="return confirm('${message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');" /></span>
                     </shiro:hasPermission>

--- a/grails-app/views/surgery/edit.gsp
+++ b/grails-app/views/surgery/edit.gsp
@@ -30,19 +30,19 @@
                 <div class="dialog">
                     <table>
                         <tbody>
-                        
+
                             <tr class="prop">
                                 <td valign="top" class="name">
                                   <label class="compulsory" for="timestamp"><g:message code="surgery.timestamp.label" default="Timestamp" /></label>
                                 </td>
                                 <td valign="top" class="value ${hasErrors(bean: surgeryInstance, field: 'timestamp', 'errors')}">
-                                    <joda:dateTimePicker name="timestamp" 
+                                    <joda:dateTimePicker name="timestamp"
                                                          value="${surgeryInstance?.timestamp}"
                                                          useZone="true"/>
 
                                 </td>
                             </tr>
-                        
+
                             <tr class="prop">
                                 <td valign="top" class="name">
                                   <label class="compulsory" for="release"><g:message code="surgery.release.label" default="Release" /></label>
@@ -52,7 +52,7 @@
 
                                 </td>
                             </tr>
-                        
+
                             <tr class="prop">
                                 <td valign="top" class="name">
                                   <label class="compulsory" for="tag"><g:message code="surgery.tag.label" default="Tag" /></label>
@@ -62,7 +62,7 @@
 
                                 </td>
                             </tr>
-                        
+
                             <tr class="prop">
                                 <td valign="top" class="name">
                                   <label class="compulsory" for="treatmentType"><g:message code="surgery.treatmentType.label" default="Treatment Type" /></label>
@@ -72,7 +72,7 @@
 
                                 </td>
                             </tr>
-                        
+
                             <tr class="prop">
                                 <td valign="top" class="name">
                                   <label for="comments"><g:message code="surgery.comments.label" default="Comments" /></label>
@@ -82,7 +82,7 @@
 
                                 </td>
                             </tr>
-                        
+
                             <tr class="prop">
                                 <td valign="top" class="name">
                                   <label class="compulsory" for="type"><g:message code="surgery.type.label" default="Type" /></label>
@@ -92,7 +92,7 @@
 
                                 </td>
                             </tr>
-                        
+
                         </tbody>
                     </table>
                 </div>

--- a/grails-app/views/surgery/show.gsp
+++ b/grails-app/views/surgery/show.gsp
@@ -71,7 +71,7 @@
                 <g:form>
                     <g:hiddenField name="id" value="${surgeryInstance?.id}" />
                     <g:hiddenField name="projectId" value="${surgeryInstance?.release?.project?.id}" />
-                    <shiro:hasPermission permission="project:${surgeryInstance?.release?.project?.id}:write">
+                    <shiro:hasPermission permission="project:${surgeryInstance?.release?.project?.id}:edit_children">
                       <span class="button"><g:actionSubmit class="edit" action="edit" value="${message(code: 'default.button.edit.label', default: 'Edit')}" /></span>
                       <span class="button"><g:actionSubmit class="delete" action="delete" value="${message(code: 'default.button.delete.label', default: 'Delete')}" onclick="return confirm('${message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');" /></span>
                     </shiro:hasPermission>

--- a/grails-app/views/surgery/show.gsp
+++ b/grails-app/views/surgery/show.gsp
@@ -21,49 +21,49 @@
             <div class="dialog">
                 <table>
                     <tbody>
-                    
+
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="surgery.timestamp.label" default="Timestamp" /></td>
-                            
+
                             <td valign="top" class="value"><joda:format value="${surgeryInstance?.timestamp}" /></td>
-                            
+
                         </tr>
-                    
+
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="surgery.release.label" default="Release" /></td>
-                            
+
                             <td valign="top" class="value"><g:link controller="animalRelease" action="show" id="${surgeryInstance?.release?.id}">${surgeryInstance?.release?.encodeAsHTML()}</g:link></td>
-                            
+
                         </tr>
-                    
+
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="surgery.tag.label" default="Tag" /></td>
-                            
+
                             <td valign="top" class="value"><g:link controller="tag" action="show" id="${surgeryInstance?.tag?.id}">${surgeryInstance?.tag?.encodeAsHTML()}</g:link></td>
-                            
+
                         </tr>
-                    
+
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="surgery.treatmentType.label" default="Treatment Type" /></td>
-                            
+
                             <td valign="top" class="value"><g:link controller="surgeryTreatmentType" action="show" id="${surgeryInstance?.treatmentType?.id}">${surgeryInstance?.treatmentType?.encodeAsHTML()}</g:link></td>
-                            
+
                         </tr>
-                    
+
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="surgery.comments.label" default="Comments" /></td>
-                            
+
                             <td valign="top" class="value">${fieldValue(bean: surgeryInstance, field: "comments")}</td>
-                            
+
                         </tr>
-                    
+
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="surgery.type.label" default="Type" /></td>
-                            
+
                             <td valign="top" class="value"><g:link controller="surgeryType" action="show" id="${surgeryInstance?.type?.id}">${surgeryInstance?.type?.encodeAsHTML()}</g:link></td>
-                            
+
                         </tr>
-                    
+
                     </tbody>
                 </table>
             </div>

--- a/grails-app/views/tag/edit.gsp
+++ b/grails-app/views/tag/edit.gsp
@@ -121,7 +121,7 @@
                                     <thead>
                                       <tr>
                                         <th></th>
-                                        <shiro:hasPermission permission="project:${tagInstance?.project?.id}:write">
+                                        <shiro:hasPermission permission="project:${tagInstance?.project?.id}:edit_children">
                                           <th/>
                                         </shiro:hasPermission>
                                         <th>Tag Type</th>
@@ -138,7 +138,7 @@
                                           <td class="rowButton">
                                             <g:link class="show" controller="sensor" action="show" id="${s?.id}"></g:link>
                                           </td>
-                                          <shiro:hasPermission permission="project:${tagInstance?.project?.id}:write">
+                                          <shiro:hasPermission permission="project:${tagInstance?.project?.id}:edit_children">
                                             <td class="rowButton">
                                               <g:link controller="sensor"
                                                       action="delete"


### PR DESCRIPTION
Added a database migration to remove old (now unused0 write permissions from database.

I also updated some usages of write permissions which I found. I did my best to use 'edit' or 'edit_children' but I'd like to get this checked by @anguss00 and @jkburges.