### PR TITLE
Creation of test database moved to a script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,7 @@ before_install:
   - gvm use grails 1.3.7
 
 before_script:
-  - psql -U postgres -c "create user aatams_test unencrypted password 'aatams_test';"
-  - psql -U postgres -c "create database aatams_test owner aatams_test;"
-  - psql -U postgres -c "create extension postgis" aatams_test
-  - psql -U postgres -c "create schema aatams authorization aatams_test;" aatams_test
-  - psql -U postgres -c "alter database aatams_test set search_path to 'aatams', 'public';" aatams_test
-  - psql -U postgres -c "alter database aatams_test set timezone to 'Australia/Hobart';" aatams_test
+  - ./init_test_db.sh
 
 script: grails test-app --echoOut
 

--- a/init_test_db.sh
+++ b/init_test_db.sh
@@ -1,0 +1,9 @@
+PSQL_ARGS=${1:--U postgres}
+psql $PSQL_ARGS -c "drop database aatams_test"
+psql $PSQL_ARGS -c "drop user aatams_test"
+psql $PSQL_ARGS -c "create user aatams_test unencrypted password 'aatams_test'"
+psql $PSQL_ARGS -c "create database aatams_test owner aatams_test"
+psql $PSQL_ARGS -c "create extension postgis" aatams_test
+psql $PSQL_ARGS -c "create schema aatams authorization aatams_test" aatams_test
+psql $PSQL_ARGS -c "alter database aatams_test set search_path to 'aatams', 'public'" aatams_test
+psql $PSQL_ARGS -c "alter database aatams_test set timezone to 'Australia/Hobart'" aatams_test


### PR DESCRIPTION
**I'm after feedback before merging**

I just needed to recreate my AATAMS test database and it seemed that it might be easier for devs to reuse this test database setup code if it's in a shell script rather than the individual commands being in the travis config. Thoughts @jkburges?