### PR TITLE
Fixes an exception when viewing individual detection records

### DIFF
--- a/grails-app/views/detection/show.gsp
+++ b/grails-app/views/detection/show.gsp
@@ -97,15 +97,14 @@
 
                               <table class="nested">
                                 <tbody>
-                                  <g:each in="${detectionInstance?.surgeries}" var="surgery">
-                                    <tr>
-                                      <td class="rowButton"><g:link class="show" controller="surgery" action="show" id="${surgery?.id}">.</g:link></td>
-                                      <td>
-                                        <g:link controller="tag" action="show" id="${surgery?.tag?.id}">${surgery?.tag?.encodeAsHTML()}</g:link>
-                                      </td>
-                                    </tr>
+                                  <g:set var="surgery" value="${detectionInstance?.surgery}" />
+                                  <tr>
+                                    <td class="rowButton"><g:link class="show" controller="surgery" action="show" id="${surgery?.id}">.</g:link></td>
+                                    <td>
+                                      <g:link controller="tag" action="show" id="${surgery?.tag?.id}">${surgery?.tag?.encodeAsHTML()}</g:link>
+                                    </td>
+                                  </tr>
 
-                                  </g:each>
                                 </tbody>
                               </table>
 


### PR DESCRIPTION
In practise, there is a 1:many relationship between detections and surgeries (this is because of tag ping code recycling, albeit a rare occurance).

Previously, this was manifest in the app with one record per detection on the list view, and then in `detection show`, the "many" surgeries being shown.

Now, multiple records will be listed where there are many surgeries, with only the one surgery being shown in the "show" view.

This has changed because of the changes to the underlying database view.