### PR TITLE
Make import date default sort for receiver export list

### DIFF
--- a/grails-app/controllers/au/org/emii/aatams/ReceiverDownloadFileController.groovy
+++ b/grails-app/controllers/au/org/emii/aatams/ReceiverDownloadFileController.groovy
@@ -19,6 +19,10 @@ class ReceiverDownloadFileController
 
     def list = {
         params.max = Math.min(params.max ? params.int('max') : grailsApplication.config.grails.gorm.default.list.max, 100)
+        if (!params.sort) {
+            params.sort = "importDate"
+            params.order = "desc"
+        }
         [receiverDownloadFileInstanceList: ReceiverDownloadFile.list(params), receiverDownloadFileInstanceTotal: ReceiverDownloadFile.count()]
     }
 

--- a/grails-app/views/receiverDownloadFile/list.gsp
+++ b/grails-app/views/receiverDownloadFile/list.gsp
@@ -30,7 +30,7 @@
                             <g:sortableColumn property="type" title="${message(code: 'receiverDownloadFile.type.label', default: 'Type')}" />
                         
                             <shiro:hasRole name="SysAdmin">
-                              <g:sortableColumn property="path" title="${message(code: 'receiverDownloadFile.path.label', default: 'Path')}" />
+                              <g:column property="path" title="${message(code: 'receiverDownloadFile.path.label', default: 'Path')}" />
                             </shiro:hasRole>
                             
                             <g:sortableColumn property="status" title="${message(code: 'receiverDownloadFile.status.label', default: 'Status')}" />


### PR DESCRIPTION
@jkburges is this cool? seemed logical to me for how we've always used that page.

Also prevents sorting on path (visible to sys admins) because it explodes