### PR TITLE
Don't count receiver events

### DIFF
--- a/grails-app/controllers/au/org/emii/aatams/ReceiverEventController.groovy
+++ b/grails-app/controllers/au/org/emii/aatams/ReceiverEventController.groovy
@@ -18,6 +18,15 @@ class ReceiverEventController extends ReportController
         doList("receiverEvent")
     }
 
+    protected def getResultList(queryName) {
+        return queryService.queryWithoutCount(
+            reportInfoService.getClassForName(queryName), params
+        )
+    }
+
+    protected def displayCountMessage(resultList, queryName) {
+    }
+
     def export =
     {
         receiverEventExportService.generateReport(params, request, response)


### PR DESCRIPTION
The count wasn't being displayed, but the (expensive) query was still being made.

(Additional) fix for https://github.com/aodn/aatams/issues/229