### PR TITLE
Do the indexing on a different thread

### DIFF
--- a/grails-app/conf/Searchable.groovy
+++ b/grails-app/conf/Searchable.groovy
@@ -7,7 +7,7 @@ searchable {
         suggestQuery: [userFriendly: true]
     ]
     mirrorChanges = true
-    bulkIndexOnStartup = true
+    bulkIndexOnStartup = "fork"
     releaseLocksOnStartup = true
 }
 


### PR DESCRIPTION
... otherwise an exception is thrown.  This needs to be revisited I think, but in any case, this is a pretty safe change because this is how it was done prior to 2ff854fa8ea680fe01df

Btw, an "AATAMS edge" would've picked up this problem a bit earlier - do we have enough resources to host such a thing?