### PR TITLE
Addresses #248

### DIFF
--- a/grails-app/views/detection/list.gsp
+++ b/grails-app/views/detection/list.gsp
@@ -36,8 +36,6 @@
 
                             <g:sortableColumn property="transmitterId" title="${message(code: 'detection.transmitterId.label', default: 'Transmitter ID')}" params="${params}"/>
 
-                            <g:sortableColumn property="transmitterName" title="${message(code: 'detection.transmitterName.label', default: 'Transmitter Name')}" params="${params}"/>
-
                             <g:sortableColumn property="transmitterSerialNumber" title="${message(code: 'detection.transmitterSerialNumber.label', default: 'Transmitter Serial Number')}" params="${params}"/>
 
                             <g:sortableColumn property="stationName" title="${message(code: 'detection.stationName.label', default: 'Station Name')}" params="${params}"/>
@@ -60,8 +58,6 @@
                             <td><g:link controller="receiverDeployment" action="show" id="${detectionInstance?.receiverDeployment?.id}">${detectionInstance.receiverDeployment}</g:link></td>
 
                             <td>${detectionInstance.transmitterId}</td>
-
-                            <td>${detectionInstance.transmitterName}</td>
 
                             <td>${detectionInstance.transmitterSerialNumber}</td>
 


### PR DESCRIPTION
The inclusion of the transmitter name column is somewhat misleading (as it depends on what users have entered in their own VUE database, rather than what's in the AATAMS DB).  It also constitutes a potential security risk w.r.t. to species information, as some users are naming their tags after the species to which they're attached, however this information is not subject to any restriction/embargo (i.e. it's always publicly visible).

For these reasons, this column has been removed.