### PR TITLE
Fix #268

### DIFF
--- a/grails-app/views/animalRelease/create.gsp
+++ b/grails-app/views/animalRelease/create.gsp
@@ -94,7 +94,7 @@
                         
                             <tr class="prop">
                                 <td valign="top" class="name">
-                                    <label for="captureLocation"><g:message code="animalRelease.captureLocation.label" default="Capture Location" /></label>
+                                    <label class="compulsory" for="captureLocation"><g:message code="animalRelease.captureLocation.label" default="Capture Location" /></label>
                                 </td>
                                 <td valign="top" class="value ${hasErrors(bean: animalReleaseInstance, field: 'captureLocation', 'errors')}">
                                   <g:point name="captureLocation" 
@@ -208,7 +208,7 @@
                         
                             <tr class="prop">
                                 <td valign="top" class="name">
-                                    <label for="releaseLocation"><g:message code="animalRelease.releaseLocation.label" default="Release Location" /></label>
+                                    <label class="compulsory" for="releaseLocation"><g:message code="animalRelease.releaseLocation.label" default="Release Location" /></label>
                                 </td>
                                 <td valign="top" class="value ${hasErrors(bean: animalReleaseInstance, field: 'releaseLocation', 'errors')}">
                                   <g:point name="releaseLocation"

--- a/grails-app/views/animalRelease/create.gsp
+++ b/grails-app/views/animalRelease/create.gsp
@@ -73,17 +73,6 @@
                         
                             <tr class="prop">
                                 <td valign="top" class="name">
-                                    <label class="compulsory" for="animal"><g:message code="animalRelease.animal.label" default="Animal" /></label>
-                                </td>
-                                <td valign="top" class="value ${hasErrors(bean: animalReleaseInstance, field: 'animal', 'errors')}">
-                                    <g:select name="animal.id" 
-                                              optionKey="id" 
-                                              noSelection="['':'New animal']"/>
-                                </td>
-                            </tr>
-                        
-                            <tr class="prop">
-                                <td valign="top" class="name">
                                     <label class="compulsory" for="captureLocality"><g:message code="animalRelease.captureLocality.label" default="Capture Locality" /></label>
                                 </td>
                                 <td valign="top" class="value ${hasErrors(bean: animalReleaseInstance, field: 'captureLocality', 'errors')}">

--- a/grails-app/views/animalRelease/edit.gsp
+++ b/grails-app/views/animalRelease/edit.gsp
@@ -94,7 +94,7 @@
 
                             <tr class="prop">
                                 <td valign="top" class="name">
-                                  <label for="captureLocation"><g:message code="animalRelease.captureLocation.label" default="Capture Location" /></label>
+                                  <label class="compulsory" for="captureLocation"><g:message code="animalRelease.captureLocation.label" default="Capture Location" /></label>
                                 </td>
                                 <td valign="top" class="value ${hasErrors(bean: animalReleaseInstance, field: 'captureLocation', 'errors')}">
                                   <g:point name="captureLocation"
@@ -273,7 +273,7 @@
 
                             <tr class="prop">
                                 <td valign="top" class="name">
-                                  <label for="releaseLocation"><g:message code="animalRelease.releaseLocation.label" default="Release Location" /></label>
+                                  <label class="compulsory" for="releaseLocation"><g:message code="animalRelease.releaseLocation.label" default="Release Location" /></label>
                                 </td>
 
                                 <td valign="top" class="value ${hasErrors(bean: animalReleaseInstance, field: 'releaseLocation', 'errors')}">

--- a/grails-app/views/animalRelease/edit.gsp
+++ b/grails-app/views/animalRelease/edit.gsp
@@ -71,19 +71,6 @@
 
                             <tr class="prop">
                                 <td valign="top" class="name">
-                                    <label class="compulsory" for="animal"><g:message code="animalRelease.animal.label" default="Animal" /></label>
-                                </td>
-                                <td valign="top" class="value ${hasErrors(bean: animalReleaseInstance, field: 'animal', 'errors')}">
-                                    <g:select name="animal.id"
-                                              from="${animalReleaseInstance?.animal}"
-                                              optionKey="id"
-                                              noSelection="['':'New animal']"
-                                              value="${animalReleaseInstance?.animal?.id}" />
-                                </td>
-                            </tr>
-
-                            <tr class="prop">
-                                <td valign="top" class="name">
                                   <label class="compulsory" for="captureLocality"><g:message code="animalRelease.captureLocality.label" default="Capture Locality" /></label>
                                 </td>
                                 <td valign="top" class="value ${hasErrors(bean: animalReleaseInstance, field: 'captureLocality', 'errors')}">


### PR DESCRIPTION
Addresses https://github.com/aodn/aatams/issues/268#issue-111758919 and https://github.com/aodn/aatams/issues/268#issuecomment-191045251 to prevent people from not entering capture and release locations and get rid of the obsolete animal field in the tag release page