### PR TITLE
Quick fix for #122

### DIFF
--- a/grails-app/migrations/rebuild_detection_view.groovy
+++ b/grails-app/migrations/rebuild_detection_view.groovy
@@ -1,6 +1,11 @@
 databaseChangeLog = {
     changeSet(author: 'dnahodil', id: '1445913902000-00', runOnChange: true, failOnError: true) {
-        createView(
+        dropView(viewName: 'valid_detection')
+        dropView(viewName: 'invalid_detection')
+        dropView(viewName: 'detection_view')
+	dropView(viewName: 'surgery_with_end_date')        
+
+	createView(
             '''
             SELECT
                 surgery.*,
@@ -17,10 +22,6 @@ databaseChangeLog = {
             ''',
             viewName: 'surgery_with_end_date'
         )
-
-        dropView(viewName: 'valid_detection')
-        dropView(viewName: 'invalid_detection')
-        dropView(viewName: 'detection_view')
 
         createView('''
             SELECT
@@ -48,6 +49,7 @@ databaseChangeLog = {
                 species.spcode,
                 species.scientific_name,
                 species.common_name,
+		species.name AS species_name,
                 invalid_reason(detection.*, receiver.*, deployment_and_recovery.*) AS invalid_reason,
                 sensor.transmitter_id AS sensor_id,
                 tag.project_id AS tag_project_id,

--- a/src/groovy/au/org/emii/aatams/detection/DetectionView.groovy
+++ b/src/groovy/au/org/emii/aatams/detection/DetectionView.groovy
@@ -43,6 +43,7 @@ class DetectionView extends Detection implements Embargoable {
     String invalidReason
     String organisationName
     String scientificName
+    String speciesName
     String sensorId
     String spcode
     String stationStationName
@@ -78,7 +79,7 @@ class DetectionView extends Detection implements Embargoable {
 
     String getSpeciesName() {
         if (!spcode) {
-            return ''
+            return "${speciesName}"
         }
 
         return "${spcode} - ${scientificName} (${commonName})"
@@ -123,6 +124,7 @@ class DetectionView extends Detection implements Embargoable {
         Detection.fromSqlRow(row, detection)
 
         detection.commonName = row.common_name
+        detection.speciesName = row.species_name
 
         if(row.embargo_date) {
             detection.embargoDate = new DateTime(row.embargo_date).withZone(DateTimeZone.UTC)
@@ -135,6 +137,7 @@ class DetectionView extends Detection implements Embargoable {
         detection.releaseProjectId = row.release_project_id
         detection.tagProjectId = row.tag_project_id
         detection.scientificName = row.scientific_name
+	detection.speciesName = row.species_name
         detection.sensorId = row.sensor_id
         detection.spcode = row.spcode
         detection.stationId = row.station_id


### PR DESCRIPTION
Implemented a quick fix for species names entered manually instead of using the drop down menu, see last paragraph of https://github.com/aodn/aatams/issues/122#issuecomment-219897627:

>  So in my opinion the following steps need to be taken in the following order:
  1. Find out all the releases that have been linked to a species in the above list and fix these up by assigning them to an existing CAAB-registered species.
  2. Once 1 is done, clean up the `species` table by removing all the entries listed above.
  3. Add constraints to the Tag Release page so that users have to use the existing, cleaned-up, drop down menu listing all CAAB-registered species.

> Obviously these steps will require quite some work, so an alternative, quick-fix, option for now would be to amend the Groovy file mentioned above by editing the ``getSpeciesName`` function to read: if (!spcode) {return "${name}"}.

