### PR TITLE
fix2 #372

### DIFF
--- a/grails-app/domain/au/org/emii/aatams/ReceiverDeployment.groovy
+++ b/grails-app/domain/au/org/emii/aatams/ReceiverDeployment.groovy
@@ -19,7 +19,7 @@ import com.vividsolutions.jts.geom.Point
  */
 class ReceiverDeployment {
     static belongsTo = [station: InstallationStation, receiver: Receiver]
-    static transients = [ 'scrambledLocation', 'active', 'latitude', 'longitude', 'deploymentInterval', 'deploymentNumber' ]
+    static transients = [ 'scrambledLocation', 'active', 'latitude', 'longitude', 'deploymentInterval' ]
     static auditable = true
 
     static hasMany = [ events: ValidReceiverEvent ]

--- a/grails-app/views/receiverDeployment/show.gsp
+++ b/grails-app/views/receiverDeployment/show.gsp
@@ -38,14 +38,7 @@
                             <td valign="top" class="value"><g:link controller="receiver" action="show" id="${receiverDeploymentInstance?.receiver?.id}">${receiverDeploymentInstance?.receiver?.encodeAsHTML()}</g:link></td>
                             
                         </tr>
-                    
-                        <tr class="prop">
-                            <td valign="top" class="name"><g:message code="receiverDeployment.deploymentNumber.label" default="Deployment Number" /></td>
-                            
-                            <td valign="top" class="value">${fieldValue(bean: receiverDeploymentInstance, field: "deploymentNumber")}</td>
-                            
-                        </tr>
-                        
+
                         <tr class="prop">
                             <td valign="top" class="name"><g:message code="receiverDeployment.deploymentDate.label" default="Deployment Date" /></td>
                             


### PR DESCRIPTION
Restores the edit capability by removing the deployment Number from the domain object and view. 

Calculating deployment number dynamically may have some computation and code cost, so I would like @xhoenner to indicate how important it is, before thinking about doing the development.

The code changes have been deployed to aatams-test-instance to test.