### PR TITLE
Fix aatams dependency issues

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -12,6 +12,7 @@ grails.project.dependency.resolution = {
     }
 
     repositories {
+        grailsRepo("http://grails.org/plugins", "grailsCentral")
         grailsHome()
         mavenLocal()
         mavenCentral()


### PR DESCRIPTION
svn.codehaus.org has been shutdown so use use its replacement http://graills.org/plugins for grails plugins instead

Failing tests to be fixed under another PR - at least we can build and run them now.