### PR TITLE
Create sequences for id in device and sensor tables for batch registration of tags

### DIFF
--- a/grails-app/migrations/changelog.groovy
+++ b/grails-app/migrations/changelog.groovy
@@ -25,4 +25,5 @@ databaseChangeLog = {
     include file: 'update_register_message.groovy'
     include file: 'match_detections_on_deployment_to_recovery.groovy'
     include file: 'valid_code_map_transmitter_type.groovy'
+    include file: 'create_device_sensor_sequences.groovy'
 }

--- a/grails-app/migrations/create_device_sensor_sequences.groovy
+++ b/grails-app/migrations/create_device_sensor_sequences.groovy
@@ -1,0 +1,5 @@
+databaseChangeLog = {
+    changeSet(author: 'xhoenner', id: '1522885790000-01') {
+        sqlFile( path: "tables/create_device_sensor_sequences.sql")
+    }
+}

--- a/grails-app/migrations/tables/create_device_sensor_sequences.sql
+++ b/grails-app/migrations/tables/create_device_sensor_sequences.sql
@@ -1,0 +1,12 @@
+--liquibase formatted sql
+
+--changeset xhoenner:baseline dbms:postgres
+create SEQUENCE device_id_seq;
+select setval('"aatams"."device_id_seq"'::regclass, (select max("id") + 1 FROM "aatams"."device"));
+ALTER TABLE device ALTER COLUMN id SET DEFAULT nextval('device_id_seq');
+ALTER SEQUENCE device_id_seq OWNED BY device.id;
+
+create SEQUENCE sensor_id_seq;
+select setval('"aatams"."sensor_id_seq"'::regclass, (select max("id") + 1 FROM "aatams"."sensor"));
+ALTER TABLE sensor ALTER COLUMN id SET DEFAULT nextval('sensor_id_seq');
+ALTER SEQUENCE sensor_id_seq OWNED BY sensor.id;


### PR DESCRIPTION
As discussed with @pmbohm, this is necessary to generate unique ids when batch registering tags via SQL script. Corresponding aatams-content PR [here](https://github.com/aodn/aatams-content/pull/78).